### PR TITLE
WebResponse QAPage/QA Validation Fix

### DIFF
--- a/src/brave/types/web/answer.py
+++ b/src/brave/types/web/answer.py
@@ -1,11 +1,12 @@
 from pydantic import BaseModel
 from pydantic import Field
+from typing import Optional
 
 
 class Answer(BaseModel):
     """A response representing an answer to a question on a forum."""
 
     text: str = Field(description="The main content of the answer.")
-    author: str = Field(description="A name string for the author of the answer.")
-    upvoteCount: int = Field(description="Number of upvotes on the answer.")
-    downvoteCount: int = Field(description="The number of downvotes on the answer.")
+    author: Optional[str] = Field(default=None, description="A name string for the author of the answer.")
+    upvoteCount: Optional[int] = Field(default=None, description="Number of upvotes on the answer.")
+    downvoteCount: Optional[int] = Field(default=None, description="The number of downvotes on the answer.")

--- a/src/brave/types/web/faq.py
+++ b/src/brave/types/web/faq.py
@@ -6,13 +6,14 @@ from pydantic import Field
 from pydantic import HttpUrl
 
 from ..shared.meta_url import MetaUrl
+from .answer import Answer
 
 
 class QAPage(BaseModel):
     """Aggreated result from a question answer page."""
 
     question: str = Field(description="The question being asked.")
-    answer: str = Field(description="The answer to the question.")
+    answer: Answer = Field(description="The answer to the question.")
 
 
 class QA(BaseModel):

--- a/src/brave/types/web/search_result.py
+++ b/src/brave/types/web/search_result.py
@@ -22,6 +22,7 @@ from .article import Article
 from .book import Book
 from .faq import FAQ
 from .faq import QA
+from .faq import QAPage
 from .location_result import LocationResult
 from .location_result import Locations
 from .product import Product
@@ -66,7 +67,7 @@ class SearchResult(Result):
     faq: Optional[FAQ] = Field(
         default=None, description="Any frequently asked questions associated with the web search result."
     )
-    qa: Optional[QA] = Field(
+    qa: Optional[QAPage] = Field(
         default=None, description="Any question answer information associated with the web search result page."
     )
     book: Optional[Book] = Field(


### PR DESCRIPTION
Modified WebResponseSearch result to appropriately use QAPage instead of QA.  Also fixed QAPage to appropriately use Answer.  Also made several fields optional as they don't always seem to be included depending on the query and response from Brave.