### PR TITLE
Reraise errors caught after sync request

### DIFF
--- a/src/brave/sync.py
+++ b/src/brave/sync.py
@@ -36,5 +36,7 @@ class Brave(BraveAPIClient):
             return response
         except requests.exceptions.HTTPError as e:
             logger.warning(f"HTTP error occurred: {e}")
+            raise e
         except requests.exceptions.RequestException as e:
             logger.warning(f"Request error occurred: {e}")
+            raise e


### PR DESCRIPTION
Hi,

In the sync client, it looks like after `requests.exceptions.HTTPError` and `requests.exceptions.RequestException` are caught, the error should be reraised?

If not true (I notice the return type is `Optional[requests.Response]`) then the possibility of being `None` is not considered after calling `_get`.

Either way, something needs fixed and I'm happy to contribute. Please let me know.